### PR TITLE
Changes required by devtools version 2.0.0, plus 'check' tidyup

### DIFF
--- a/R/datashield.r
+++ b/R/datashield.r
@@ -76,7 +76,7 @@ dsadmin.install_package <- function(opal, pkg, githubusername=NULL, ref=NULL) {
     lapply(opal, function(o){dsadmin.install_package(o, pkg, githubusername=githubusername, ref=ref)})
   } else {
     if (! (is.null(ref) || is.null(githubusername))) {
-      query <- list(name=paste(name,pkg,sep="/"),ref=ref)
+      query <- list(name=paste(githubusername,pkg,sep="/"),ref=ref)
     } else {
       query <- list(name=pkg)
     }

--- a/R/datashield.r
+++ b/R/datashield.r
@@ -42,6 +42,7 @@ dsadmin.package_descriptions <- function(opal, fields=NULL) {
 #' @title Get Datashield Package Description
 #'
 #' @param opal Opal object or list of opal objects.
+#' @param pkg Package name.
 #' @param fields A character vector giving the fields to extract from each package's DESCRIPTION file in addition to the default ones, or NULL (default). Unavailable fields result in NA values.
 #' @export
 dsadmin.package_description <- function(opal, pkg, fields=NULL) {
@@ -172,7 +173,6 @@ dsadmin.rm_method <- function(opal, name, type="aggregate") {
 #' @title Remove Datashield Methods
 #' 
 #' @param opal Opal object or list of opal objects.
-#' @param name Name of the method, as it is accessed by Datashield users.
 #' @param type Type of the method: "aggregate" or "assign". Default is NULL (=all type of methods).
 #' @export
 dsadmin.rm_methods <- function(opal, type=NULL) {

--- a/R/datashield.r
+++ b/R/datashield.r
@@ -61,7 +61,7 @@ dsadmin.package_description <- function(opal, pkg, fields=NULL) {
   }
 }
 
-#' Install a package from Datashield public package repository or (if Git reference is provided) from Datashield source repository on GitHub.
+#' Install a package from Datashield public package repository or (if Git reference and GitHub username is provided) from Datashield source repository on GitHub.
 #'
 #' @title Install Datashield Package
 #'
@@ -75,7 +75,7 @@ dsadmin.install_package <- function(opal, pkg, githubusername=NULL, ref=NULL) {
   if(is.list(opal)){
     lapply(opal, function(o){dsadmin.install_package(o, pkg, githubusername=githubusername, ref=ref)})
   } else {
-    if (! (is.null(ref) || is.null(githubusername))) {
+    if((!is.null(ref)) && (!is.null(githubusername))) {
       query <- list(name=paste(githubusername,pkg,sep="/"),ref=ref)
     } else {
       query <- list(name=pkg)

--- a/R/datashield.r
+++ b/R/datashield.r
@@ -73,7 +73,7 @@ dsadmin.package_description <- function(opal, pkg, fields=NULL) {
 #' @export
 dsadmin.install_package <- function(opal, pkg, githubusername=NULL, ref=NULL) {
   if(is.list(opal)){
-    lapply(opal, function(o){dsadmin.install_package(o, pkg, ref=ref)})
+    lapply(opal, function(o){dsadmin.install_package(o, pkg, githubusername=githubusername, ref=ref)})
   } else {
     if (! (is.null(ref) || is.null(githubusername))) {
       query <- list(name=paste(name,pkg,sep="/"),ref=ref)

--- a/R/datashield.r
+++ b/R/datashield.r
@@ -67,16 +67,18 @@ dsadmin.package_description <- function(opal, pkg, fields=NULL) {
 #'
 #' @param opal Opal object or list of opal objects. 
 #' @param pkg Package name.
+#' @param githubusername GitHub username of git repository. If NULL (default), try to install from Datashield package repository. 
 #' @param ref Desired git reference (could be a commit, tag, or branch name). If NULL (default), try to install from Datashield package repository.
 #' @return TRUE if installed
 #' @export
-dsadmin.install_package <- function(opal, pkg, ref=NULL) {
+dsadmin.install_package <- function(opal, pkg, githubusername=NULL, ref=NULL) {
   if(is.list(opal)){
     lapply(opal, function(o){dsadmin.install_package(o, pkg, ref=ref)})
   } else {
-    query <- list(name=pkg)
-    if (!is.null(ref)) {
-      query <- append(query,list(ref=ref))
+    if (! (is.null(ref) || is.null(githubusername))) {
+      query <- list(name=paste(name,pkg,sep="/"),ref=ref)
+    } else {
+      query <- list(name=pkg)
     }
     opal:::.post(opal, "datashield", "packages", query=query)
     dsadmin.installed_package(opal, pkg)

--- a/R/opal.r
+++ b/R/opal.r
@@ -23,7 +23,7 @@ oadmin.install_package <- function(opal, pkg, repos=NULL) {
   } else {
     if (!oadmin.installed_package(opal, pkg)) {
       # default repos
-      defaultrepos <- c(getOption("repos"), "http://cran.silver.arjuna.com", "http://cran.rstudio.com")
+      defaultrepos <- c(getOption("repos"), "http://cran.obiba.org/stable", "http://cran.rstudio.com")
       if (getOption("repos") != "@CRAN@") {
         defaultrepos <- append(defaultrepos, getOption("repos"))
       }

--- a/R/opal.r
+++ b/R/opal.r
@@ -23,7 +23,7 @@ oadmin.install_package <- function(opal, pkg, repos=NULL) {
   } else {
     if (!oadmin.installed_package(opal, pkg)) {
       # default repos
-      defaultrepos <- c(getOption("repos"), "http://cran.obiba.org/stable", "http://cran.rstudio.com")
+      defaultrepos <- c(getOption("repos"), "http://cran.silver.arjuna.com", "http://cran.rstudio.com")
       if (getOption("repos") != "@CRAN@") {
         defaultrepos <- append(defaultrepos, getOption("repos"))
       }

--- a/man/dsadmin.install_package.Rd
+++ b/man/dsadmin.install_package.Rd
@@ -2,7 +2,7 @@
 \alias{dsadmin.install_package}
 \title{Install Datashield Package}
 \usage{
-  dsadmin.install_package(opal, pkg, ref = NULL)
+  dsadmin.install_package(opal, pkg, githubusername=NULL, ref = NULL)
 }
 \arguments{
   \item{opal}{Opal object or list of opal objects.}

--- a/man/dsadmin.install_package.Rd
+++ b/man/dsadmin.install_package.Rd
@@ -9,6 +9,10 @@
 
   \item{pkg}{Package name.}
 
+  \item{githubusername}{GitHub username of git repository.
+  If NULL (default), try to install from Datashield package
+  repository.}
+
   \item{ref}{Desired git reference (could be a commit, tag,
   or branch name). If NULL (default), try to install from
   Datashield package repository.}

--- a/man/dsadmin.package_description.Rd
+++ b/man/dsadmin.package_description.Rd
@@ -7,6 +7,8 @@
 \arguments{
   \item{opal}{Opal object or list of opal objects.}
 
+  \item{pkg}{Package name.}
+
   \item{fields}{A character vector giving the fields to
   extract from each package's DESCRIPTION file in addition
   to the default ones, or NULL (default). Unavailable

--- a/man/dsadmin.rm_methods.Rd
+++ b/man/dsadmin.rm_methods.Rd
@@ -7,9 +7,6 @@
 \arguments{
   \item{opal}{Opal object or list of opal objects.}
 
-  \item{name}{Name of the method, as it is accessed by
-  Datashield users.}
-
   \item{type}{Type of the method: "aggregate" or "assign".
   Default is NULL (=all type of methods).}
 }

--- a/tests/install-admin-development.R
+++ b/tests/install-admin-development.R
@@ -15,6 +15,6 @@ if (!require('rjson', character.only=TRUE)) {
 	install.packages('rjson', repos=c('http://cran.rstudio.com'), dependencies=TRUE)
 }
 # Install opal packages from github
-devtools::install_github('opal', username='datashield', ref='master')
+devtools::install_github('datashield/opal', ref='master')
 # Install opaladmin package from github
-devtools::install_github('opaladmin', username='datashield', ref='master')
+devtools::install_github('datashield/opaladmin', ref='master')

--- a/tests/install-development.R
+++ b/tests/install-development.R
@@ -15,6 +15,6 @@ if (!require('rjson', character.only=TRUE)) {
 	install.packages('rjson', repos=c('http://cran.rstudio.com'), dependencies=TRUE)
 }
 # Install opal packages from github
-devtools::install_github('opal', username='datashield', ref='master')
+devtools::install_github('datashield/opal', ref='master')
 # Install opaladmin package from github
-devtools::install_github('opaladmin', username='datashield', ref='master')
+devtools::install_github('datashield/opaladmin', ref='master')


### PR DESCRIPTION
'devtool' 2.0 requires the 'repo' for the format 'account_name/repo_name', rather that 'repo' and 'username' argument used in version 1.X of 'devtools'

Also some of the easy tidyups requested by 'devtools::check()'